### PR TITLE
second parameter name

### DIFF
--- a/AeroVisualizerRedux/Win32Api.cs
+++ b/AeroVisualizerRedux/Win32Api.cs
@@ -15,7 +15,7 @@ namespace AeroVisualizerRedux
         public static extern bool DwmIsCompositionEnabled();
 
         [DllImport("dwmapi.dll", EntryPoint = "#131", PreserveSig = false)]
-        public static extern void DwmSetColorizationParameters(ref DWM_COLORIZATION_PARAMS parameters, bool uUnknown);
+        public static extern void DwmSetColorizationParameters(ref DWM_COLORIZATION_PARAMS parameters, bool bIsTemporary);
 
         public const int WM_GETICON = 0x7F;
 


### PR DESCRIPTION
if the second parameter is false(0), it saves the changed colorization parameters to the registry, and if true(1), it does not save it to registry and it will be discarded when dwm is restarted